### PR TITLE
REFACTOR: user uid is obtained from the context

### DIFF
--- a/cloud/functions/src/index.ts
+++ b/cloud/functions/src/index.ts
@@ -46,11 +46,11 @@ exports.registerNewUserOnDatabase = functions.auth.user().onCreate(event => {
     return Promise.all(promises)
 });
 
-exports.sendNewMessageNotification = functions.database.ref('chat/{messageId}').onCreate(chatSnap => {
+exports.sendNewMessageNotification = functions.database.ref('chat/{messageId}').onCreate((chatSnap, context) => {
     const message = chatSnap.child('message').val();
 
     return message ? admin.database()
-        .ref('users').child(chatSnap.child('userId').val())
+        .ref(`users/${context.auth.uid}`)
         .once('value', userSnap => {
             const userName = userSnap.child('name').val();
 


### PR DESCRIPTION
Considering this is a demonstrative project getting the uid from the context seems more suitable. UID on the message can be maintained for other tasks. String interpolation is added to concatenate reference without the need for an extra dot child.